### PR TITLE
Fix bug #44

### DIFF
--- a/services/cooperation.js
+++ b/services/cooperation.js
@@ -32,6 +32,8 @@ const cooperationService = {
     const { role: currentUserRole } = currentUser
     const { price, status } = updateData
 
+    if (price && status) throw createForbiddenError()
+
     const cooperation = await Cooperation.findById(id)
 
     if (price) {

--- a/services/cooperation.js
+++ b/services/cooperation.js
@@ -32,7 +32,7 @@ const cooperationService = {
     const { role: currentUserRole } = currentUser
     const { price, status } = updateData
 
-    if (price && status) throw createForbiddenError()
+    if (price !== undefined && status) throw createForbiddenError()
 
     const cooperation = await Cooperation.findById(id)
 


### PR DESCRIPTION
Fix bug #44: A user can update both cooperation price and status at the same time.

Fixed by adding a new check if the price and status are passed at the same time. If so, a forbidden error is thrown.

<img width="687" alt="Screenshot 2024-02-09 at 12 10 49" src="https://github.com/Space2Study-UA-1125/backEnd/assets/110097862/0957fedd-dca8-493e-ae71-d8a58671a138">