### PR TITLE
Fixed the bug #37

### DIFF
--- a/models/offer.js
+++ b/models/offer.js
@@ -84,7 +84,7 @@ const offerSchema = new Schema(
 offerSchema.statics.calcTotalOffers = async function (category, subject, authorRole) {
   const categoryTotalOffersQty = await this.countDocuments({ authorRole })
   await Category.findByIdAndUpdate(category, { $set: { [`totalOffers.${authorRole}`]: categoryTotalOffersQty } }).exec()
-  const subjectTotalOffersQty = await this.countDocuments({ subject })
+  const subjectTotalOffersQty = await this.countDocuments({ subject, authorRole })
   await Subject.findByIdAndUpdate(subject, { $set: { [`totalOffers.${authorRole}`]: subjectTotalOffersQty } }).exec()
 }
 


### PR DESCRIPTION
Description: Total offers in subjects are calculated for all roles. It should be calculated for specific subject and separated by roles.

I have added authorRole to the countDocuments for subjectTotalOffersQty. Now it correctly calculate the total offers.
![image](https://github.com/Space2Study-UA-1125/backEnd/assets/49125203/78344b50-336c-4578-a1f8-a240e626e5bc)
![image](https://github.com/Space2Study-UA-1125/backEnd/assets/49125203/2755c5e6-4e6f-4ab2-b999-e24ac0659b88)
![image](https://github.com/Space2Study-UA-1125/backEnd/assets/49125203/e8cfc31b-0847-4670-af56-568591d88293)

