### PR TITLE
Fix an incorrect counting of items when getting offers with parameters

### DIFF
--- a/utils/categories/categoriesAggregateOptions.js
+++ b/utils/categories/categoriesAggregateOptions.js
@@ -34,7 +34,7 @@ const categoriesAggregateOptions = (query) => {
     },
     {
       $facet: {
-        items: [{ $skip: Number(skip) }, { $limit: Number(limit) }],
+        items: [],
         count: [{ $count: 'count' }]
       }
     },


### PR DESCRIPTION
Fixed an incorrect counting of items when getting offers with skip and limit parameters.

<img width="893" alt="Screenshot 2024-03-02 at 15 04 47" src="https://github.com/Space2Study-UA-1125/backEnd/assets/110097862/9a0443bc-afa4-43ad-b952-b2428e5a7f54">
